### PR TITLE
feat: disable delete button while editing the same todo

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -40,7 +40,12 @@ function App ({ todos, visibilityFilter, updateTodo }) {
         timeout={700}
         classNames='slide'
       >
-        <Todo item={todo} editItem={editItem} index={idx} />
+        <Todo
+          item={todo}
+          editItem={editItem}
+          index={idx}
+          itemIdToBeUpdated={itemIdToBeUpdated}
+        />
       </CSSTransition>
       )
     : (visibilityFilter === 'active'
@@ -71,31 +76,31 @@ function App ({ todos, visibilityFilter, updateTodo }) {
         {memoizedForm}
         <SwitchTransition mode='out-in'>
           {
-                  todos.length === 0
-                    ? <CSSTransition
-                        key={0}
-                        timeout={300}
-                        classNames='fade'
-                      >
-                      <EmptyList text='' />
-                      </CSSTransition>
-                    : <CSSTransition
-                        key={1}
-                        timeout={300}
-                        classNames='fade'
-                      >
-                      <ul>
-                        <TransitionGroup>
-                          {
-                          todoList.length === 0
-                            ? <EmptyList text={visibilityFilter} />
-                            : todoList
-                        }
-                        </TransitionGroup>
-                      </ul>
-                    </CSSTransition>
+            todos.length === 0
+              ? <CSSTransition
+                  key={0}
+                  timeout={300}
+                  classNames='fade'
+                >
+                <EmptyList text='' />
+              </CSSTransition>
+              : <CSSTransition
+                  key={1}
+                  timeout={300}
+                  classNames='fade'
+                >
+                <ul>
+                  <TransitionGroup>
+                    {
+                    todoList.length === 0
+                      ? <EmptyList text={visibilityFilter} />
+                      : todoList
+                  }
+                  </TransitionGroup>
+                </ul>
+                </CSSTransition>
 
-                }
+          }
         </SwitchTransition>
         <TriStateButton />
 

--- a/src/components/Todo/index.js
+++ b/src/components/Todo/index.js
@@ -5,7 +5,16 @@ import CheckBoxOutlineBlankIcon from '@material-ui/icons/CheckBoxOutlineBlank'
 import DeleteIcon from '@material-ui/icons/Delete'
 import EditIcon from '@material-ui/icons/Edit'
 
-function Todo ({ item: { id, todo, isCompleted }, index, editItem, toggleTodo, deleteTodo }) {
+function Todo (props) {
+  const {
+    item: { id, todo, isCompleted },
+    index,
+    editItem,
+    itemIdToBeUpdated,
+    toggleTodo,
+    deleteTodo
+  } = props
+
   return (
     <li className={isCompleted ? 'done' : ''}>
       <span className='label'>{todo}</span>
@@ -25,8 +34,10 @@ function Todo ({ item: { id, todo, isCompleted }, index, editItem, toggleTodo, d
         </button>
         {/* Todo delete button */}
         <button
-          type='button' className='btn-picto'
+          type='button'
+          className='btn-picto'
           onClick={() => deleteTodo(id)}
+          disabled={id === itemIdToBeUpdated}
         >
           <DeleteIcon style={{ color: '#FFF' }} />
 


### PR DESCRIPTION
Closes #7 

## About this PR
This is a feature PR that will disable deleting todo while it's in editing state. This will help avoid a situation when user accidentally deletes the same todo he/she was editing.